### PR TITLE
Add files via upload

### DIFF
--- a/pars2files.py
+++ b/pars2files.py
@@ -7,6 +7,7 @@ import do_ocr
 import tempfile
 import json
 import base64
+import re
 
 def pars2files(reqtype, sourcefile, areadict, canvheight, canvwidth, 
     rollangle=0, brightnessrate=1.0, sharpnessrate=1.0, contrastrate=1.0, boxblur=0, enlargerate=2, 
@@ -213,8 +214,10 @@ def pars2files(reqtype, sourcefile, areadict, canvheight, canvwidth,
 
                 reslist.append(str(firstres)) #each next cell in data row
             #
+            
+            filename = re.sub('[^a-zA-Z0-9א-ת_]', '_', reslist[1]) #file named by page num and second cell in each row
 
-            pagepath = resdir.name + '\\' + str(pagenum) + "_" + reslist[1] + '.pdf' #file named by page num and second cell in each row
+            pagepath = resdir.name + '\\' + str(pagenum) + "_" + filename + '.pdf' 
 
             pdfWriterObj = PyPDF2.PdfFileWriter()
 


### PR DESCRIPTION
added substitution of non Hebrew or English characters or numbers in the name of the newly created pdf files, so that the program would not fail in case the text returned by OCR includes characters that cannot be used in a file name.